### PR TITLE
Update plugins to make them work with current versions of Rocket.Chat

### DIFF
--- a/plugins/rocketchat_messages
+++ b/plugins/rocketchat_messages
@@ -28,10 +28,10 @@ def main(argv):
     rocketApi = RocketChat(rocketUser, rocketPass, server_url=rocketServer)
     response = rocketApi.statistics()
 
-    print('total.value %d' % response.json()['statistics']['totalChannelMessages'])
-    print('channel.value %d' % response.json()['statistics']['totalChannelMessages'])
-    print('group.value %d' % response.json()['statistics']['totalPrivateGroupMessages'])
-    print('direct.value %d' % response.json()['statistics']['totalDirectMessages'])
+    print('total.value %d' % response.json()['totalChannelMessages'])
+    print('channel.value %d' % response.json()['totalChannelMessages'])
+    print('group.value %d' % response.json()['totalPrivateGroupMessages'])
+    print('direct.value %d' % response.json()['totalDirectMessages'])
   return
 
 if __name__ == "__main__":

--- a/plugins/rocketchat_rooms
+++ b/plugins/rocketchat_rooms
@@ -28,10 +28,10 @@ def main(argv):
     rocketApi = RocketChat(rocketUser, rocketPass, server_url=rocketServer)
     response = rocketApi.statistics()
 
-    print('total.value %d' % response.json()['statistics']['totalRooms'])
-    print('channel.value %d' % response.json()['statistics']['totalChannels'])
-    print('group.value %d' % response.json()['statistics']['totalPrivateGroups'])
-    print('direct.value %d' % response.json()['statistics']['totalDirect'])
+    print('total.value %d' % response.json()['totalRooms'])
+    print('channel.value %d' % response.json()['totalChannels'])
+    print('group.value %d' % response.json()['totalPrivateGroups'])
+    print('direct.value %d' % response.json()['totalDirect'])
   return
 
 if __name__ == "__main__":

--- a/plugins/rocketchat_users
+++ b/plugins/rocketchat_users
@@ -25,9 +25,9 @@ def main(argv):
     rocketApi = RocketChat(rocketUser, rocketPass, server_url=rocketServer)
     response = rocketApi.statistics()
 
-    print('total.value %d' % response.json()['statistics']['totalUsers'])
-    print('online.value %d' % response.json()['statistics']['onlineUsers'])
-    print('away.value %d' % response.json()['statistics']['awayUsers'])
+    print('total.value %d' % response.json()['totalUsers'])
+    print('online.value %d' % response.json()['onlineUsers'])
+    print('away.value %d' % response.json()['awayUsers'])
   return
 
 if __name__ == "__main__":


### PR DESCRIPTION
The plugins do not work with current versions of Rocket.Chat (3.16.x).

According to https://developer.rocket.chat/api/rest-api/endpoints/miscellaneous/statistics, there is no key 'statistics' in the response JSON.

The changes in this pull request make the plugins in this repository work again.